### PR TITLE
Explicitly add versioningit as a build dependency.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ stages:
   jobs:
     - job: Skip
       pool:
-        vmImage: 'ubuntu-22.04'
+        vmImage: 'ubuntu-latest'
       variables:
         DECODE_PERCENTS: 'false'
         RET: 'true'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 819078685aac356251bb8270c56b39e380f37e745d29291d8d0c4ec6159d0132
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - python {{ python_min }}
     - pip
     - setuptools
+    - versioningit
   run:
     - python >={{ python_min }}
     - numpy >=1.21


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] <del>Reset the build number to `0` (if the version changed)<del>
* [x] Ensured the license file is being packaged.

We have problems with the forge feedstock for mdacli and believe that it might be a result of the dynamic versioning being broken in the conda package for GridDataFormats. We get this line in the [build log](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1450726&view=logs&jobId=7b6f2c87-f3a7-5133-8d84-7c03a75d9dfc)
```
mdanalysis 2.10.0 has requirement GridDataFormats>=0.4.0, but you have griddataformats 0.0.0.
```

The latest (passing) [build log](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1442341&view=logs&jobId=7b6f2c87-f3a7-5133-8d84-7c03a75d9dfc&j=7b6f2c87-f3a7-5133-8d84-7c03a75d9dfc&t=9eb77fd2-8ddd-5444-8fc0-71cb28dcb736) for GridDataFormats  show this:

```
-----------------------------------------------
noarch/griddataformats-1.1.0-pyhd8ed1ab_0.conda
-----------------------------------------------
-- Size: 5.3MB
-- SHA256: 37f803512605d338dc8d626d5e7b1312e7ddc67b635403b6322d0c1e3e6c4efd
-- Contents:
?rw-r--r-- 0/0       7985 2026-01-23 00:52:20 info/about.json 
?rw-r--r-- 0/0       1429 2026-01-23 00:52:20 info/files 
?rw-r--r-- 0/0          0 2026-01-23 00:52:20 info/git 
?rw-r--r-- 0/0         43 2026-01-23 00:52:20 info/hash_input.json 
?rw-r--r-- 0/0        333 2026-01-23 00:52:20 info/index.json 
?rw-r--r-- 0/0       7637 2026-01-22 22:14:27 info/licenses/COPYING.LESSER 
?rw-r--r-- 0/0         75 2026-01-23 00:52:20 info/link.json 
?rw-r--r-- 0/0       6510 2026-01-23 00:52:20 info/paths.json 
?rw-r--r-- 0/0        609 2026-01-23 00:52:20 info/recipe/conda_build_config.yaml 
?rw-r--r-- 0/0       2748 2026-01-23 00:52:20 info/recipe/meta.yaml 
?rw-r--r-- 0/0       1304 2026-01-23 00:49:38 info/recipe/meta.yaml.template 
?rw-r--r-- 0/0       1541 2026-01-23 00:50:32 info/recipe/recipe-scripts-license.txt 
?rw-r--r-- 0/0         45 2026-01-23 00:52:20 info/test/run_test.py 
?rw-r--r-- 0/0         17 2026-01-23 00:52:20 info/test/test_time_dependencies.json 
?rw-rw-r-- 0/0      40909 2026-01-23 00:52:17 site-packages/gridData/OpenDX.py 
?rw-rw-r-- 0/0       3781 2026-01-23 00:52:17 site-packages/gridData/__init__.py 
?rw-rw-r-- 0/0      35927 2026-01-23 00:52:17 site-packages/gridData/core.py 
?rw-rw-r-- 0/0      10391 2026-01-23 00:52:17 site-packages/gridData/gOpenMol.py 
?rw-rw-r-- 0/0      10384 2026-01-23 00:52:17 site-packages/gridData/mrc.py 
?rw-rw-r-- 0/0          2 2026-01-23 00:52:17 site-packages/gridData/tests/__init__.py 
?rw-rw-r-- 0/0    2044544 2026-01-23 00:52:17 site-packages/gridData/tests/datafiles/1jzv.ccp4 
?rw-rw-r-- 0/0     172553 2026-01-23 00:52:17 site-packages/gridData/tests/datafiles/EMD-3001.map.bz2 
?rw-rw-r-- 0/0        864 2026-01-23 00:52:17 site-packages/gridData/tests/datafiles/__init__.py 
?rw-rw-r-- 0/0    3651716 2026-01-23 00:52:17 site-packages/gridData/tests/datafiles/ispg_0.mrc 
?rw-rw-r-- 0/0     660236 2026-01-23 00:52:17 site-packages/gridData/tests/datafiles/nAChR_M2_water.plt 
?rw-rw-r-- 0/0       1792 2026-01-23 00:52:17 site-packages/gridData/tests/datafiles/test.ccp4 
?rw-rw-r-- 0/0        261 2026-01-23 00:52:17 site-packages/gridData/tests/datafiles/test.dx 
?rw-rw-r-- 0/0        499 2026-01-23 00:52:17 site-packages/gridData/tests/datafiles/test.dx.gz 
?rw-rw-r-- 0/0       2752 2026-01-23 00:52:17 site-packages/gridData/tests/test_dx.py 
?rw-rw-r-- 0/0       1207 2026-01-23 00:52:17 site-packages/gridData/tests/test_gOpenMol.py 
?rw-rw-r-- 0/0       8205 2026-01-23 00:52:17 site-packages/gridData/tests/test_grid.py 
?rw-rw-r-- 0/0      11042 2026-01-23 00:52:17 site-packages/gridData/tests/test_mrc.py 
?rw-rw-r-- 0/0          5 2026-01-23 00:52:20 site-packages/griddataformats-0.0.0.dist-info/INSTALLER 
?rw-rw-r-- 0/0       4978 2026-01-23 00:52:17 site-packages/griddataformats-0.0.0.dist-info/METADATA 
?rw-rw-r-- 0/0       3195 2026-01-23 00:52:17 site-packages/griddataformats-0.0.0.dist-info/RECORD 
?rw-rw-r-- 0/0          0 2026-01-23 00:52:17 site-packages/griddataformats-0.0.0.dist-info/REQUESTED 
?rw-rw-r-- 0/0         92 2026-01-23 00:52:17 site-packages/griddataformats-0.0.0.dist-info/WHEEL 
?rw-rw-r-- 0/0        111 2026-01-23 00:52:17 site-packages/griddataformats-0.0.0.dist-info/direct_url.json 
?rw-rw-r-- 0/0        961 2026-01-23 00:52:17 site-packages/griddataformats-0.0.0.dist-info/licenses/AUTHORS 
?rw-rw-r-- 0/0      35147 2026-01-23 00:52:17 site-packages/griddataformats-0.0.0.dist-info/licenses/COPYING 
```

This broken versioning was also happening in the mdacli build but was fixed by explicitly adding `setuptools_scm` to the requirements in the recipe.